### PR TITLE
Fix getCanvasWindow import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const apis = [
 
 async function importMockWindow() {
   // @ts-expect-error: Missing files
-  const getCanvasWindow = await import('jest-canvas-mock/lib/window').then(res => res.default || res)
+  const getCanvasWindow = await import('jest-canvas-mock/lib/window').then(res => res.default?.default || res.default || res)
 
   const canvasWindow = getCanvasWindow({ document: window.document })
 


### PR DESCRIPTION
Thank you so much for this library! While I was setting it up, I was getting this issue:

```sh
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
TypeError: getCanvasWindow is not a function
 ❯ importMockWindow node_modules/vitest-canvas-mock/dist/index.js:20:24
     18|     return(res.default || res)});
     19|   const canvasWindow = getCanvasWindow({ document: window.document });
     20|   apis.forEach((api) => {
       |                        ^
     21|     global[api] = canvasWindow[api];
     22|     global.window[api] = canvasWindow[api];
```

This PR proposes a fix for that issue.