### PR TITLE
Fix import file extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ const apis = [
 
 async function importMockWindow() {
   // @ts-expect-error: Missing files
-  const getCanvasWindow = await import('jest-canvas-mock/lib/window').then(res => res.default?.default || res.default || res)
+  const getCanvasWindow = await import('jest-canvas-mock/lib/window.js').then(res => res.default?.default || res.default || res)
 
   const canvasWindow = getCanvasWindow({ document: window.document })
 


### PR DESCRIPTION
In our vite project, I get the following error when using this package as a replacement for jest-canvas-mock:
```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Error: Cannot find module '/app/node_modules/jest-canvas-mock/lib/window' imported from /app/node_modules/vitest-canvas-mock/dist/index.js
Did you mean to import jest-canvas-mock/lib/window.js?
 ❯ new NodeError node:internal/errors:399:5
 ❯ finalizeResolution node:internal/modules/esm/resolve:326:11
 ❯ moduleResolve node:internal/modules/esm/resolve:945:10
 ❯ defaultResolve node:internal/modules/esm/resolve:1153:11
 ❯ nextResolve node:internal/modules/esm/loader:163:28
 ❯ ESMLoader.resolve node:internal/modules/esm/loader:838:30
 ❯ ESMLoader.getModuleJob node:internal/modules/esm/loader:424:18
 ❯ ESMLoader.import node:internal/modules/esm/loader:525:22
 ❯ importModuleDynamically node:internal/modules/esm/translators:110:35
 ❯ importModuleDynamicallyCallback node:internal/process/esm_loader:35:14

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
Serialized Error: {
  "code": "ERR_MODULE_NOT_FOUND",
}
```

I am not sure why this happens, we don't have any resolve.extensions configured in vite, but we do use the VuetifyResolver from [unplugin-vue-components](https://github.com/antfu/unplugin-vue-components), maybe that one messes something up.
Anyways, this change should make the package more stable to use, regardless of the specific vite config of the project.