### PR TITLE
fix: guard against window being absent in global

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,11 +32,15 @@ async function importMockWindow() {
   })
 }
 
-importMockWindow()
+if ('window' in global) {
+  importMockWindow()
+}
 
 afterAll(() => {
   delete global.jest
-  delete global.window.jest
+  if ('window' in global) {
+    delete global.window.jest
+  }
 })
 
 export {}


### PR DESCRIPTION
A vitest test configured to run in a non-browser environment, e.g. with a comment like this at the top:
```ts
/*
* @vitest-environment node
*/
```
... fails when `vitest-canvas-mock` is installed and enabled, because `window` does not exist in the `global` object:
```
ReferenceError: window is not defined
 ❯ importMockWindow node_modules/vitest-canvas-mock/dist/index.js:17:52
```

So guard against this case by acting only when `window` is present in `global`.

Tested this with `patch-package` in my project with this patch:
```patch
diff --git a/node_modules/vitest-canvas-mock/dist/index.js b/node_modules/vitest-canvas-mock/dist/index.js
index f03ec66..3cbc2fa 100644
--- a/node_modules/vitest-canvas-mock/dist/index.js
+++ b/node_modules/vitest-canvas-mock/dist/index.js
@@ -20,8 +20,12 @@ async function importMockWindow() {
     global.window[api] = canvasWindow[api];
   });
 }
-importMockWindow();
+if ('window' in global) {
+  importMockWindow();
+}
 afterAll(() => {
   delete global.jest;
-  delete global.window.jest;
+  if ('window' in global) {
+    delete global.window.jest;
+  }
 });
```