### PR TITLE
fix: implement CanvasRenderingContext2D.reset()

### DIFF
--- a/__tests__/classes/CanvasRenderingContext2D.reset.js
+++ b/__tests__/classes/CanvasRenderingContext2D.reset.js
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+let canvas;
+let ctx;
+
+beforeEach(() => {
+  canvas = document.createElement('canvas');
+  ctx = canvas.getContext('2d');
+  canvas.width = 400;
+  canvas.height = 300;
+});
+
+describe('reset', () => {
+  it('should be a function', () => {
+    expect(typeof ctx.reset).toBe('function');
+  });
+
+  it('should be callable without throwing', () => {
+    expect(() => ctx.reset()).not.toThrow();
+  });
+
+  it('should reset the current transform to identity', () => {
+    ctx.setTransform(1, 2, 3, 4, 5, 6);
+    expect(ctx.currentTransform).toEqual(new DOMMatrix([1, 2, 3, 4, 5, 6]));
+    ctx.reset();
+    expect(ctx.currentTransform).toEqual(new DOMMatrix([1, 0, 0, 1, 0, 0]));
+  });
+
+  it('should reset fillStyle to the default', () => {
+    ctx.fillStyle = '#ff0000';
+    ctx.reset();
+    expect(ctx.fillStyle).toBe('#000000');
+  });
+
+  it('should reset strokeStyle to the default', () => {
+    ctx.strokeStyle = '#00ff00';
+    ctx.reset();
+    expect(ctx.strokeStyle).toBe('#000000');
+  });
+
+  it('should reset globalAlpha to 1', () => {
+    ctx.globalAlpha = 0.5;
+    ctx.reset();
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it('should reset globalCompositeOperation to source-over', () => {
+    ctx.globalCompositeOperation = 'multiply';
+    ctx.reset();
+    expect(ctx.globalCompositeOperation).toBe('source-over');
+  });
+
+  it('should reset lineWidth to 1', () => {
+    ctx.lineWidth = 5;
+    ctx.reset();
+    expect(ctx.lineWidth).toBe(1);
+  });
+
+  it('should reset lineCap to butt', () => {
+    ctx.lineCap = 'round';
+    ctx.reset();
+    expect(ctx.lineCap).toBe('butt');
+  });
+
+  it('should reset lineJoin to miter', () => {
+    ctx.lineJoin = 'bevel';
+    ctx.reset();
+    expect(ctx.lineJoin).toBe('miter');
+  });
+
+  it('should reset font to the default', () => {
+    ctx.font = '20px Arial';
+    ctx.reset();
+    expect(ctx.font).toBe('10px sans-serif');
+  });
+
+  it('should reset textAlign to start', () => {
+    ctx.textAlign = 'center';
+    ctx.reset();
+    expect(ctx.textAlign).toBe('start');
+  });
+
+  it('should reset textBaseline to alphabetic', () => {
+    ctx.textBaseline = 'middle';
+    ctx.reset();
+    expect(ctx.textBaseline).toBe('alphabetic');
+  });
+
+  it('should reset shadowColor to transparent', () => {
+    ctx.shadowColor = 'rgba(255, 0, 0, 0.5)';
+    ctx.reset();
+    expect(ctx.shadowColor).toBe('rgba(0, 0, 0, 0)');
+  });
+
+  it('should reset shadowBlur to 0', () => {
+    ctx.shadowBlur = 7;
+    ctx.reset();
+    expect(ctx.shadowBlur).toBe(0);
+  });
+
+  it('should reset shadowOffsetX to 0', () => {
+    ctx.shadowOffsetX = 3;
+    ctx.reset();
+    expect(ctx.shadowOffsetX).toBe(0);
+  });
+
+  it('should reset shadowOffsetY to 0', () => {
+    ctx.shadowOffsetY = 4;
+    ctx.reset();
+    expect(ctx.shadowOffsetY).toBe(0);
+  });
+
+  it('should reset filter to none', () => {
+    ctx.filter = 'blur(2px)';
+    ctx.reset();
+    expect(ctx.filter).toBe('none');
+  });
+
+  it('should reset imageSmoothingEnabled to true', () => {
+    ctx.imageSmoothingEnabled = false;
+    ctx.reset();
+    expect(ctx.imageSmoothingEnabled).toBe(true);
+  });
+
+  it('should reset miterLimit to 10', () => {
+    ctx.miterLimit = 3;
+    ctx.reset();
+    expect(ctx.miterLimit).toBe(10);
+  });
+
+  it('should reset lineDashOffset to 0', () => {
+    ctx.lineDashOffset = 5;
+    ctx.reset();
+    expect(ctx.lineDashOffset).toBe(0);
+  });
+
+  it('should clear the current path', () => {
+    ctx.rect(10, 10, 50, 50);
+    const pathBefore = ctx.__getPath();
+    expect(pathBefore.length).toBeGreaterThan(1);
+
+    ctx.reset();
+
+    // After reset the path should be reduced back to a single beginPath event.
+    expect(ctx.__getPath()).toHaveLength(1);
+  });
+
+  it('should push a reset event', () => {
+    ctx.reset();
+    const events = ctx.__getEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('reset');
+  });
+});

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -32,6 +32,7 @@ const testFuncs = [
   'strokeRect',
   'rect',
   'roundRect',
+  'reset',
   'resetTransform',
   'translate',
   'moveTo',
@@ -1368,6 +1369,53 @@ export default class CanvasRenderingContext2D {
     const event = createCanvasEvent('removeHitRegion', getTransformSlice(this), { id });
 
     this._events.push(event);
+  }
+
+  /**
+   * Reset the current drawing state to the default values and clear the
+   * current path. Mirrors the standard CanvasRenderingContext2D.reset()
+   * method:
+   * https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/reset
+   */
+  reset() {
+    // Reset transform to identity at the current stack index.
+    this._transformStack[this._stackIndex][0] = 1;
+    this._transformStack[this._stackIndex][1] = 0;
+    this._transformStack[this._stackIndex][2] = 0;
+    this._transformStack[this._stackIndex][3] = 1;
+    this._transformStack[this._stackIndex][4] = 0;
+    this._transformStack[this._stackIndex][5] = 0;
+
+    // Reset all drawing-state properties to their defaults.
+    this._directionStack[this._stackIndex] = 'inherit';
+    this._fillStyleStack[this._stackIndex] = '#000000';
+    this._filterStack[this._stackIndex] = 'none';
+    this._fontStack[this._stackIndex] = '10px sans-serif';
+    this._globalAlphaStack[this._stackIndex] = 1.0;
+    this._globalCompositeOperationStack[this._stackIndex] = 'source-over';
+    this._imageSmoothingEnabledStack[this._stackIndex] = true;
+    this._imageSmoothingQualityStack[this._stackIndex] = 'low';
+    this._lineCapStack[this._stackIndex] = 'butt';
+    this._lineDashStack[this._stackIndex] = [];
+    this._lineDashOffsetStack[this._stackIndex] = 0;
+    this._lineJoinStack[this._stackIndex] = 'miter';
+    this._lineWidthStack[this._stackIndex] = 1;
+    this._miterLimitStack[this._stackIndex] = 10;
+    this._shadowBlurStack[this._stackIndex] = 0;
+    this._shadowColorStack[this._stackIndex] = 'rgba(0, 0, 0, 0)';
+    this._shadowOffsetXStack[this._stackIndex] = 0;
+    this._shadowOffsetYStack[this._stackIndex] = 0;
+    this._strokeStyleStack[this._stackIndex] = '#000000';
+    this._textAlignStack[this._stackIndex] = 'start';
+    this._textBaselineStack[this._stackIndex] = 'alphabetic';
+    this._clipStack[this._stackIndex] = [];
+
+    // Reset the current path to a single beginPath event.
+    this.__clearPath();
+
+    // Record a 'reset' event for snapshot tests, matching the style of
+    // resetTransform(), save(), and restore().
+    this._events.push(createCanvasEvent('reset', getTransformSlice(this), {}));
   }
 
   resetTransform() {


### PR DESCRIPTION
Fixes #29 — \`ctx.reset()\` was throwing \`TypeError: ctx.reset is not a function\`.

## What was broken

The mock exposed most \`CanvasRenderingContext2D\` methods via a \`testFuncs\` list and prototype-installed functions, but \`reset\` was never added. Any code calling \`ctx.reset()\` to clear the drawing state and current path would crash with the error above.

## What I changed

- Added \`'reset'\` to the \`testFuncs\` list in \`src/classes/CanvasRenderingContext2D.js\`, so the method is wrapped with \`vi.fn()\` and is inspectable in tests like the other context methods.
- Added a new \`reset()\` method that:
  - Resets the current transform to identity at the active stack index.
  - Resets all drawing-state properties (fillStyle, strokeStyle, font, globalAlpha, globalCompositeOperation, lineWidth, lineCap, lineJoin, miterLimit, lineDash, lineDashOffset, shadowBlur, shadowColor, shadowOffsetX, shadowOffsetY, imageSmoothingEnabled, imageSmoothingQuality, filter, direction, textAlign, textBaseline) to their spec defaults.
  - Clears the current path back to a single \`beginPath\` event via the existing \`__clearPath()\` helper.
  - Records a \`reset\` event so it is observable through \`__getEvents()\`.
- Added a new test file \`__tests__/classes/CanvasRenderingContext2D.reset.js\` covering:
  - method existence
  - callability
  - transform reset
  - default value reset for each drawing-state property
  - path reset
  - event recording

## Tested by

- New \`CanvasRenderingContext2D.reset.js\` test file: 23 tests, all pass.
- Full test suite: 84 files, 616 tests, all pass.
- Lint: clean on both modified files.

## Spec reference

MDN: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/reset