### PR TITLE
fix(CanvasRenderingContext2D): change miterLimit event type from 'lineWidth' to 'miterLimit'

### DIFF
--- a/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
+++ b/__tests__/classes/__snapshots__/CanvasRenderingContext2D.__getEvents.js.snap
@@ -1280,7 +1280,7 @@ exports[`__getEvents > should have an event when miterLimit is set 1`] = `
       0,
       0,
     ],
-    "type": "lineWidth",
+    "type": "miterLimit",
   },
 ]
 `;

--- a/src/classes/CanvasRenderingContext2D.js
+++ b/src/classes/CanvasRenderingContext2D.js
@@ -1224,7 +1224,7 @@ export default class CanvasRenderingContext2D {
 
     if (Number.isFinite(result) && result > 0) {
       this._miterLimitStack[this._stackIndex] = result;
-      const event = createCanvasEvent('lineWidth', getTransformSlice(this), {
+      const event = createCanvasEvent('miterLimit', getTransformSlice(this), {
         value: result,
       });
       this._events.push(event);


### PR DESCRIPTION
Same fix as https://github.com/hustcc/jest-canvas-mock/pull/127